### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9
       - run: npm install --production


### PR DESCRIPTION
Fixes warning messages related to checkout and node-setup actions which uses deprecated node versions.

<img src="https://github.com/Nick-Gabe/Nick-Gabe/assets/1580205/85390a94-6e3f-4b59-b100-e8f27030a1a6">
